### PR TITLE
Create separate build artifact for main

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -1,11 +1,17 @@
 plugins {
     `java-library`
-//    `maven-publish`
+    `maven-publish`
 }
 
 project.group = "com.github.appujet"
 project.version = findProperty("version") as String 
 val archivesBaseName = "jiosaavn"
+
+tasks {
+    publish {
+        dependsOn(publishToMavenLocal)
+    }
+}
 
 dependencies {
     compileOnly(libs.lavaplayer)
@@ -40,3 +46,12 @@ build.apply {
     jar.mustRunAfter(clean)
     sourcesJar.mustRunAfter(jar)
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("main") {
+            from(components["java"])
+        }
+    }
+}
+

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -21,6 +21,7 @@ lavalinkPlugin {
     // Assuming libs and versions are defined elsewhere
     apiVersion = libs.versions.lavalink.api
     serverVersion = libs.versions.lavalink.server
+    configurePublishing = false
 }
 
 
@@ -77,6 +78,13 @@ publishing {
             authentication {
                 create<BasicAuthentication>("basic")
             }
+        }
+    }
+
+    publications {
+        create<MavenPublication>("jiosaavn-plugin") {
+            artifactId = "jiosaavn-plugin"
+            from(components["java"])
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,7 @@
 rootProject.name = "jiosaavn-plugin-base"
 
-include("plugin")
-project(":plugin").name = "jiosaavn-plugin"
 include("main")
+include("plugin")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 


### PR DESCRIPTION
This allows for direct use outside of Lavalink

Setting the name of the plugin in the settings script had the side effect of conflicting with the publish plugin for main. This is worked around by instead applying the name in the plugin publish artifact, which is now explicitly configured in this project's buildscript instead of by Lavalink.