### PR TITLE
Add beta release workflow and update build versioning

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,16 +1,9 @@
-name: Release
+name: Release Beta
 
 on:
-  workflow_dispatch:
-    inputs:
-      prerelease:
-        description: Whether or not this is a prerelease
-        type: boolean
-        default: false
-        required: true
-#  push:
-#    branches:
-#      - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -34,7 +27,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           RELEASE_TARGET: ${{ github.sha }}
-          PRERELEASE: "false"
+          PRERELEASE: "true"
+          GITHUB_SHA: ${{ github.sha }}
           USERNAME: ${{ secrets.USERNAME }}
           PASSWORD: ${{ secrets.PASSWORD }}
-        run: ./gradlew --no-daemon build publish githubRelease -x test
+        run: ./gradlew --no-daemon build githubRelease


### PR DESCRIPTION
Introduces a GitHub Actions workflow for beta releases triggered on master branch pushes. Updates build.gradle.kts to support prerelease versioning using commit SHA, sets archive file names accordingly, and ensures Maven publication uses the correct version and artifact.